### PR TITLE
:wrench: Removing Extra Spaces in Seed Phrase Initialization

### DIFF
--- a/src/components/UserInfo/index.tsx
+++ b/src/components/UserInfo/index.tsx
@@ -24,6 +24,11 @@ export function UserData() {
     const [collectionAddress, setCollectionAddress] = useState<string>("");
     const [isTestnet, setIsTestnet] = useState<boolean>(false);
 
+    const handleSetMnemonic = (value: string) => {
+        const trimmed = value.replace(/\s+/g, ' ').trim();
+        setMnemonic(trimmed);
+    };
+
     const handleUserData = async () => {
         setError("");
         if (mnemonic === "") {
@@ -83,10 +88,10 @@ export function UserData() {
     }
 
     const handleInputSeedChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-        setMnemonic(event.target.value);
+        handleSetMnemonic(event.target.value);
     };
     const handleSeedPaste = (event: React.ClipboardEvent) => {
-        setMnemonic(event.clipboardData.getData('text'));
+        handleSetMnemonic(event.clipboardData.getData('text'));
     };
 
     const handleInputWalletTypeChange = (newValue: { value: string, label: string }) => {
@@ -117,7 +122,7 @@ export function UserData() {
                     </div>
 
                     <p><b>Enter seed:</b></p>
-                    <input type="text" 
+                    <input type="text"
                         onChange={handleInputSeedChange}
                         onPaste={handleSeedPaste} />
 


### PR DESCRIPTION
### Description
In this pull request, I have implemented a feature to remove extra spaces from the beginning and middle of a seed phrase input. The key enhancement here is that the input phrase remains as it was pasted, but the edited version is utilized during wallet initialization.

### Changes Made
I've added code to ensure that any additional spaces within the seed phrase are removed when initializing the wallet. This improves the user experience by allowing them to input the seed phrase as it is, without worrying about spaces.

### How to Test
1. Input a seed phrase with extra spaces at the beginning and middle, e.g., `"apple  banana   cherry"`.
2. Initialize the wallet using this seed phrase.
3. Verify that the wallet initializes successfully, and the seed phrase is processed without extra spaces, resulting in `"apple banana cherry"` being used.
